### PR TITLE
improve readme syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # TSWeChat
-A high copy WeChat, written by Swift.
+A WeChat alternative, written in Swift.
 
 ## Requirements
 


### PR DESCRIPTION
This improves the readme syntax.

1) `A high copy WeChat` doesn't mean much. I've changed `copy` to `alternative` which sound a lot less like plagiarism while still keeping the reference to WeChat.

2) `written by Swift` would mean the author is actually named `Swift` - The correct preposition should be `in`