### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/Chinese_README.md
+++ b/Chinese_README.md
@@ -6,7 +6,7 @@ A [WeChat](https://itunes.apple.com/cn/app/wei/id414478124) alternative, written
 - iOS 8.0+ / Mac OS X 10.9+
 - Xcode 7.2+
 
-##预览
+## 预览
 在终端里面运行 `pod install`，然后运行`TSWeChat.xcworkspace` 来查看所有的 UI
 
 ## 特色

--- a/README.md
+++ b/README.md
@@ -70,10 +70,10 @@ TSWeChat is released under the MIT license. See [LICENSE](https://github.com/hil
 - Multilanguage support
 - And so on...
 
-##Contributing
+## Contributing
 - All kinds of contributions (enhancements, new features, documentation & code improvements, issues & bugs reporting & todo task) are welcome. Let's make it better. XD
 
-##Contact
+## Contact
 Follow and contact me on [Twitter](http://twitter.com/hilenlai) or [Sina Weibo](http://weibo.com/laihailong).
 
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
